### PR TITLE
Rewrite the config with the current user

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,8 @@
 mkdir -p ~/.config/pipewire/pipewire.conf.d
-cp ./sink-virtual-surround-7.1.conf ~/.config/pipewire/pipewire.conf.d/
+
+USER_HOME=$(eval echo "~$USER")
+sed "s|/home/deck|$USER_HOME|g" ./sink-virtual-surround-7.1.conf > ~/.config/pipewire/pipewire.conf.d/sink-virtual-surround-7.1.conf
+
 touch  ~/.config/pipewire/pipewire.conf.d/virtual-sink.conf
 cp ./oal_dflt.wav ./atmos.wav ~/.config/pipewire
 #from  https://airtable.com/appayGNkn3nSuXkaz/shruimhjdSakUPg2m/tbloLjoZKWJDnLtTc


### PR DESCRIPTION
Hey, thanks a lot for this project, it made setting this up a lot easier than some of the docs & threads I was reading!

The errors to debug when this fails due to the file being not found is pretty painful to find, so rewriting it during the install seems worthwhile or using a relative path if that's possible (unconfirmed on my side).

Also `sudo` wasn't needed on the service restart on my machine (Ubuntu 24.10) and outright failed, so there may be benefits to protecting against that but I've avoided that in this change.